### PR TITLE
Fix case-sensitive classname (for linux systems)

### DIFF
--- a/examples/eveonline.php
+++ b/examples/eveonline.php
@@ -29,7 +29,7 @@ $credentials = new Credentials(
 
 // Instantiate the Eve Online service using the credentials, http client, storage mechanism for the token and profile scope
 /** @var EveOnline $eveService */
-$eveService = $serviceFactory->createService('eveonline', $credentials, $storage, array(''));
+$eveService = $serviceFactory->createService('EveOnline', $credentials, $storage, array(''));
 
 if (!empty($_GET['code'])) {
     // This was a callback request from Eve Online, get the token


### PR DESCRIPTION
The linux filesystem are case-sensitive, whereas windows filesystem isn't. 

The example code fails on linux, but works fine on windows because it tries to include the file with lowercase e and o of "eveonline".
